### PR TITLE
Fixed incorrect 'parent' property re-declaration.

### DIFF
--- a/RATreeView/RATreeNodeInfo.m
+++ b/RATreeView/RATreeNodeInfo.m
@@ -30,7 +30,7 @@
 @property (nonatomic, readwrite) NSInteger siblingsNumber;
 @property (nonatomic, readwrite) NSInteger positionInSiblings;
 
-@property (strong, nonatomic, readwrite) RATreeNodeInfo *parent;
+@property (weak, nonatomic, readwrite) RATreeNodeInfo *parent;
 @property (strong, nonatomic, readwrite) NSArray *children;
 
 @property (strong, nonatomic, readwrite) RATreeNode *parentTreeNode;


### PR DESCRIPTION
This caused the following warning in Xcode: "Property attribute in class extension does not match the primary class".
Introduced with commit: https://github.com/Augustyniak/RATreeView/commit/caf2abccebb71abe2fe73036803b9be1e9159140#diff-ed4da06bdf44c605bf7fabf6161822b3L31
