### PR TITLE
Making -indexPathForItem public

### DIFF
--- a/RATreeView/RATreeView+Private.h
+++ b/RATreeView/RATreeView+Private.h
@@ -1,4 +1,3 @@
-
 //The MIT License (MIT)
 //
 //Copyright (c) 2013 Rafał Augustyniak
@@ -27,7 +26,6 @@
 @property (weak, nonatomic) UITableView *tableView;
 
 - (RATreeNode *)treeNodeForIndex:(NSInteger)index;
-- (NSIndexPath *)indexPathForItem:(id)item;
 - (void)setupTreeStructure;
 
 - (void)collapseCellForTreeNode:(RATreeNode *)treeNode;

--- a/RATreeView/RATreeView+Private.m
+++ b/RATreeView/RATreeView+Private.m
@@ -1,4 +1,3 @@
-
 //The MIT License (MIT)
 //
 //Copyright (c) 2013 Rafał Augustyniak
@@ -68,11 +67,6 @@
 - (RATreeNode *)treeNodeForIndex:(NSInteger)index
 {
   return [self.treeNodeCollectionController treeNodeForIndex:index];
-}
-
-- (NSIndexPath *)indexPathForItem:(id)item
-{
-  return [NSIndexPath indexPathForRow:[self.treeNodeCollectionController indexForItem:item] inSection:0];
 }
 
 #pragma mark Collapsing and Expanding Rows

--- a/RATreeView/RATreeView.h
+++ b/RATreeView/RATreeView.h
@@ -1,4 +1,3 @@
-
 //The MIT License (MIT)
 //
 //Copyright (c) 2013 Rafał Augustyniak
@@ -163,6 +162,7 @@ typedef enum RATreeViewRowAnimation {
 // Accessing Cells
 - (UITableViewCell *)cellForItem:(id)item;
 - (NSArray *)visibleCells;
+- (NSIndexPath *)indexPathForItem:(id)item;
 
 // Scrolling the TreeView
 - (void)scrollToRowForItem:(id)item atScrollPosition:(RATreeViewScrollPosition)scrollPosition animated:(BOOL)animated;

--- a/RATreeView/RATreeView.m
+++ b/RATreeView/RATreeView.m
@@ -1,4 +1,3 @@
-
 //The MIT License (MIT)
 //
 //Copyright (c) 2013 Rafał Augustyniak
@@ -298,6 +297,11 @@
 - (NSArray *)visibleCells
 {
   return [self.tableView visibleCells];
+}
+
+- (NSIndexPath *)indexPathForItem:(id)item
+{
+    return [NSIndexPath indexPathForRow:[self.treeNodeCollectionController indexForItem:item] inSection:0];
 }
 
 #pragma mark Scrolling the TreeView


### PR DESCRIPTION
This function was previously in RATreeView+Private, but I think it would be useful to be able to access it anywhere a RATreeView exists, so I moved it to RATreeView.

Similar to this issue: https://github.com/Augustyniak/RATreeView/issues/43