### PR TITLE
Fix endUpdates sort issue

### DIFF
--- a/RATreeView/Private Files/RABatchChanges.m
+++ b/RATreeView/Private Files/RABatchChanges.m
@@ -123,7 +123,7 @@ typedef NS_ENUM(NSInteger, RABatchChangeType) {
 {
   self.batchChangesCounter--;
   if (self.batchChangesCounter == 0) {
-    [self.operationsStorage sortedArrayUsingSelector:@selector(compare:)];
+    [self.operationsStorage sortUsingSelector:@selector(compare:)];
     
     for (RABatchChangeEntity *entity in self.operationsStorage) {
       entity.updatesBlock();


### PR DESCRIPTION
I got strange crashes when running endUpdates, so I looked into the code and the sort method looked incorrect. This change this fixed my crashes.
