### PR TITLE
Modified RATreeView itemForRowAtPoint to return nil, when point isn't inside

### DIFF
--- a/RATreeView/RATreeView.m
+++ b/RATreeView/RATreeView.m
@@ -378,7 +378,7 @@
 - (id)itemForRowAtPoint:(CGPoint)point
 {
   NSIndexPath *indexPath = [self.tableView indexPathForRowAtPoint:point];
-  return [self treeNodeForIndexPath:indexPath].item;
+  return !indexPath ? nil : [self treeNodeForIndexPath:indexPath].item;
 }
 
 - (id)itemsForRowsInRect:(CGRect)rect


### PR DESCRIPTION
Currently, when argument 'point' does not point to a cell, the method 'itemForRowAtPoint' returns the first cell. I believe it should return nil, as does 'indexPathForRowAtPoint' for UITableView.
