### PR TITLE
Support for iOS 8 Custom Actions

### DIFF
--- a/RATreeView/Private Files/RATreeView+TableViewDelegate.m
+++ b/RATreeView/Private Files/RATreeView+TableViewDelegate.m
@@ -188,6 +188,15 @@
   }
 }
 
+- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+	if ([self.delegate respondsToSelector:@selector(treeView:editActionsForItem:)]) {
+		RATreeNode *treeNode = [self treeNodeForIndexPath:indexPath];
+		return [self.delegate treeView:self editActionsForItem:treeNode.item];
+	}
+	return nil;
+}
+
 
 #pragma mark - Tracking the Removal of Views
 

--- a/RATreeView/Private Files/RATreeView+TableViewDelegate.m
+++ b/RATreeView/Private Files/RATreeView+TableViewDelegate.m
@@ -190,11 +190,11 @@
 
 - (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-	if ([self.delegate respondsToSelector:@selector(treeView:editActionsForItem:)]) {
-		RATreeNode *treeNode = [self treeNodeForIndexPath:indexPath];
-		return [self.delegate treeView:self editActionsForItem:treeNode.item];
-	}
-	return nil;
+  if ([self.delegate respondsToSelector:@selector(treeView:editActionsForItem:)]) {
+    RATreeNode *treeNode = [self treeNodeForIndexPath:indexPath];
+    return [self.delegate treeView:self editActionsForItem:treeNode.item];
+  }
+  return nil;
 }
 
 

--- a/RATreeView/Private Files/RATreeView+UIScrollView.m
+++ b/RATreeView/Private Files/RATreeView+UIScrollView.m
@@ -235,12 +235,12 @@
 
 - (UIPanGestureRecognizer *)panGestureRecognizer
 {
-  return self.panGestureRecognizer;
+  return self.tableView.panGestureRecognizer;
 }
 
 - (UIPinchGestureRecognizer *)pinchGestureRecognizer
 {
-  return self.pinchGestureRecognizer;
+  return self.tableView.pinchGestureRecognizer;
 }
 
 

--- a/RATreeView/RATreeView.h
+++ b/RATreeView/RATreeView.h
@@ -347,6 +347,17 @@ typedef enum RATreeViewRowAnimation {
 - (BOOL)treeView:(RATreeView *)treeView shouldIndentWhileEditingRowForItem:(id)item;
 
 
+/**
+ *  Asks the data source for the edit actions for an item. This is an iOS 8 only method.
+ *
+ *  @praram treeView	The tree-view object requesting this information.
+ *  @param item			An item identifying a cell in the tree view.
+ *
+ *  @return An NSArray of `UITableViewRowAction` objects to show for editing.
+ */
+- (NSArray *)treeView:(RATreeView *)treeView editActionsForItem:(id)item;
+
+
 ///------------------------------------------------
 /// @name Tracking the Removal of Views
 ///------------------------------------------------


### PR DESCRIPTION
Added the following method to the RATreeViewDataSource:

treeView:editActionsForItem:

This method is a proxy for the tableView:editActionsForRowAtIndexPath: delegate method.

This [gist](https://gist.github.com/IMcD23/f51688b8e30d76d414a2) has an example of how to use the new features. This allows for swipe actions similar to the iOS 8 mail app.