### PR TITLE
Call `treeView:didCollapseRowForItem` and `treeView:didExpandRowForIt…

### DIFF
--- a/RATreeView/Private Files/RATreeView+TableViewDelegate.m
+++ b/RATreeView/Private Files/RATreeView+TableViewDelegate.m
@@ -280,7 +280,10 @@
   [CATransaction setCompletionBlock:^{
     if ([self.delegate respondsToSelector:@selector(treeView:didCollapseRowForItem:)] &&
         informDelegate) {
-      [self.delegate treeView:self didCollapseRowForItem:treeNode.item];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            //Content size of the UITableView isn't updates when completion block of the CATransaction is called. To make it possible for the user of the RATreeView to get a correct content size in the implementation of the 'treeView:didCollapseRowForItem' RATreeView calls this method in the next run loop.
+            [self.delegate treeView:self didCollapseRowForItem:treeNode.item];
+        });
     }
   }];
   
@@ -300,7 +303,10 @@
   [CATransaction setCompletionBlock:^{
     if ([self.delegate respondsToSelector:@selector(treeView:didExpandRowForItem:)] &&
         informDelegate) {
-      [self.delegate treeView:self didExpandRowForItem:treeNode.item];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            //Content size of the UITableView isn't updates when completion block of the CATransaction is called. To make it possible for the user of the RATreeView to get a correct content size in the implementation of the 'treeView:didExpandRowForItem' RATreeView calls this method in the next run loop.
+            [self.delegate treeView:self didExpandRowForItem:treeNode.item];
+        });
     }
   }];
     


### PR DESCRIPTION
…em` methods one run loop later so that `contentSize` of the RATreeView is correct when the mentioned methods are called.