### PR TITLE
Fix problem with scroll view background after initializing RATreeView…

### DIFF
--- a/RATreeView/RATreeView/RATreeView.m
+++ b/RATreeView/RATreeView/RATreeView.m
@@ -88,6 +88,13 @@
   self.rowsCollapsingAnimation = RATreeViewRowAnimationBottom;
 }
 
+- (void)awakeFromNib
+{
+  [super awakeFromNib];
+
+  self.tableView.backgroundColor = [UIColor clearColor];
+}
+
 #pragma mark Scroll View
 
 - (UIScrollView *)scrollView


### PR DESCRIPTION
… from xib on iOS 9

Fixes problems described in #124 and #129. It looks that iOS 9 changes the color of the underlying scroll view in `awakeFromNib` method which is called only when `RATreeView` is initialised using *xib*. 