### PR TITLE
Fix table view delegate message forwarding

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATableView.m
+++ b/RATreeView/RATreeView/Private Files/RATableView.m
@@ -48,6 +48,7 @@
   if (_tableViewDelegate == tableViewDelegate) {
     return;
   }
+  [super setDelegate:nil];
   _tableViewDelegate = tableViewDelegate;
   [super setDelegate:self];
 }
@@ -57,6 +58,7 @@
   if (self.scrollViewDelegate == delegate) {
     return;
   }
+  [super setDelegate:nil];
   self.scrollViewDelegate = delegate;
   [super setDelegate:self];
 }


### PR DESCRIPTION
I've encountered an issue with message forwarding on my iPad (Mini 2 iOS 8.1.3 FWIW). UITableViewDelegate methods were not called.

The root cause is that UITableView caches the results of respondsToSelector calls for all delegate methods and does it at the very moment when a new delegate is set. Thus, it happened when the delegate was set from commonInit, and at that moment self.tableViewDelegate was still nil. Later on, since the delegate was set to the same instance (self) in setTableViewDelegate, UITableView skipped updating that cache and was assuming all methods to be still not implemented, no calls were made, and the table was not interactable.

Resetting the delegate on UITableView first before setting it forced it to refresh the cache and calls were then received as expected.