### PR TITLE
Swift Example fix (issue #195)

### DIFF
--- a/Examples/RATreeViewBasicExampleSwift/TreeViewController.swift
+++ b/Examples/RATreeViewBasicExampleSwift/TreeViewController.swift
@@ -111,7 +111,7 @@ class TreeViewController: UIViewController, RATreeViewDelegate, RATreeViewDataSo
 
         var index = 0
         if let parent = parent {
-            parent.children.indexOf({ dataObject in
+            index = parent.children.indexOf({ dataObject in
                 return dataObject === item
             })!
             parent.removeChild(item)


### PR DESCRIPTION
Fixed bug in Swift Example: wrong child was deleted due to incorrect index
