### PR TITLE
Use isEqual method to compare treeNode item

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATreeNodeController.m
+++ b/RATreeView/RATreeView/Private Files/RATreeNodeController.m
@@ -85,7 +85,7 @@
 
 - (RATreeNodeController *)controllerForItem:(id)item
 {
-  if (item == self.treeNode.item) {
+  if ([item isEqual:self.treeNode.item]) {
     return self;
   }
   
@@ -127,7 +127,7 @@
 
 - (NSInteger)lastVisibleDescendatIndexForItem:(id)item
 {
-  if (self.treeNode.item == item) {
+  if ([self.treeNode.item isEqual:item]) {
     return [self lastVisibleDescendatIndex];
   }
   


### PR DESCRIPTION
Using "==" operator cause unexpected compare results in iOS 8. I tested on iOS 8.2 with item as NSNumber object. It runs ok on simulator but real device.