### PR TITLE
`privateCollapseAndCollapseChildren:` fix

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATreeNodeController.m
+++ b/RATreeView/RATreeView/Private Files/RATreeNodeController.m
@@ -180,6 +180,10 @@
     for (RATreeNodeController *controller in self.childControllers) {
       [controller collapseAndCollapseChildren:collapseChildren];
     }
+  } else {
+      for (RATreeNodeController *controller in self.childControllers) {
+          [controller invalidate];
+      }
   }
   
   [self.parentController invalidateTreeNodesAfterChildAtIndex:[self.parentController.childControllers indexOfObject:self]];


### PR DESCRIPTION
After expand and collapse a cell I have an issue with `cellForItem:` for its child cells. After cell is collapsed without `collapseChildren` option, child cells are not invalidated, and `indexPathForItem:` returns valid indexPath,  so `cellForItem:` returns incorrect cell (one from below). 
This caused a lot of unexpected behavior. 