### PR TITLE
Fix compile issue on Xcode 11

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATreeView+Enums.m
+++ b/RATreeView/RATreeView/Private Files/RATreeView+Enums.m
@@ -97,12 +97,14 @@
 
 + (RATreeViewStyle)treeViewStyleForTableViewStyle:(UITableViewStyle)tableViewStyle
 {
-  switch (tableViewStyle) {
-    case UITableViewStylePlain:
-      return RATreeViewStylePlain;
-    case UITableViewStyleGrouped:
-      return RATreeViewStyleGrouped;
-  }
+    switch (tableViewStyle) {
+        case UITableViewStylePlain:
+            return RATreeViewStylePlain;
+        case UITableViewStyleGrouped:
+            return RATreeViewStyleGrouped;
+        default:
+            return RATreeViewStylePlain;
+    }
 }
 #pragma mark Scroll Positions
 


### PR DESCRIPTION
![Screenshot 2019-07-02 at 11 11 47](https://user-images.githubusercontent.com/544727/60500504-be2d4a00-9cba-11e9-96b4-ca3078931f06.png)

Returns `RATreeViewStylePlain`  as a *default* in 
```swift
+ (RATreeViewStyle)treeViewStyleForTableViewStyle:(UITableViewStyle)tableViewStyle
```