### PR TITLE
Update RATreeView+Enums.m

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATreeView+Enums.m
+++ b/RATreeView/RATreeView/Private Files/RATreeView+Enums.m
@@ -102,6 +102,11 @@
       return RATreeViewStylePlain;
     case UITableViewStyleGrouped:
       return RATreeViewStyleGrouped;
+//Oggerschummer: Add missing enum value to avoid compilation error
+#ifdef __IPHONE_13_0      
+  case UITableViewStyleInsetGrouped:
+      return RATreeViewStyleGrouped;
+#endif
   }
 }
 #pragma mark Scroll Positions


### PR DESCRIPTION
iOS 13 adds a new UITableViewStyle "UITableViewStyleInsetGrouped" that is not yet handled by RATreeView.
This change does map it to the existing RATreeViewStyle "RATreeViewStyleGrouped" to avoid compile time errors.
Further investigations may be necessary.